### PR TITLE
Moves a hanging parenthesis that breaks the wikipedia link

### DIFF
--- a/views/dashboard/dash.ejs
+++ b/views/dashboard/dash.ejs
@@ -21,7 +21,7 @@
         answers to be freely posted, regardless of <a href="https://meta.stackexchange.com/q/384922/">established
             community consensus</a> on such content.</p>
     <p>In turn, this allows incorrect information (colloquially referred to as &quot;<a
-            href="https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence">hallucinations</a>&quot;) and
+            href="https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence)">hallucinations</a>&quot;) and
         plagiarism to proliferate unchecked on the platform. This destroys trust in the platform, as <a
             href="https://web.archive.org/web/20230531103704/https://stackoverflow.com/help/gpt-policy">Stack Overflow,
             Inc. has previously noted</a>.</p>

--- a/views/dashboard/dash.ejs
+++ b/views/dashboard/dash.ejs
@@ -21,7 +21,7 @@
         answers to be freely posted, regardless of <a href="https://meta.stackexchange.com/q/384922/">established
             community consensus</a> on such content.</p>
     <p>In turn, this allows incorrect information (colloquially referred to as &quot;<a
-            href="https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence">hallucinations</a>)&quot;) and
+            href="https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence">hallucinations</a>&quot;) and
         plagiarism to proliferate unchecked on the platform. This destroys trust in the platform, as <a
             href="https://web.archive.org/web/20230531103704/https://stackoverflow.com/help/gpt-policy">Stack Overflow,
             Inc. has previously noted</a>.</p>


### PR DESCRIPTION
Repairs an extra paren:

![nebWInT 1](https://github.com/mousetail/openletter/assets/47993606/c0860a5a-8104-4d8f-a90d-7400346917ad)

This parenthesis was supposed to be in the link URL, but was accidentally left outside of it. This causes the link to fail (leads to https://en.wikipedia.org/wiki/Hallucination_(artificial_intelligence ) and for it to look visually... unappealing.