### PR TITLE
minor wording change to explain empty diamonds

### DIFF
--- a/views/dashboard/signing.ejs
+++ b/views/dashboard/signing.ejs
@@ -18,8 +18,8 @@
         <aside class="mt-4">
             <i class="fas fa-info-circle"></i>
             <p>
-                If you're a moderator, your signature will have a diamond shown next to it automatically. If you're a
-                former moderator and you
+                If you're a moderator, your signature will have a ♦ shown next to it automatically. If you're a
+                former moderator, your signature will have a ◊, but if you
                 would like this to be displayed, please contact <a
                     href="https://chat.stackexchange.com/users/490835/mousetail">Mousetail</a>.
             </p>


### PR DESCRIPTION
Only a minor wording change to explain the difference between the ♦ and ◊ symbols. Certainly not worth merging if this causes any complications to existing signatures or anything like that.