### PR TITLE
Introduced persistent dark mode

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -2,6 +2,41 @@ $(() => {
     let expanded = false;
     let text;
 
+    const switcher = {
+        darkMode: false,
+        init() {
+            try {
+                const storageValue = window.localStorage.getItem("darkMode");
+                const darkMode = storageValue === "true";
+                this.switchMode(darkMode);
+            } catch (e) {
+                //ignore
+            }
+        },
+        switchMode(darkMode) {
+            if (darkMode) {
+                let link = document.createElement('link');
+                link.href = 'stylesheets/dark.css';
+                link.rel = 'stylesheet';
+                link.id = 'dark-sheet';
+                document.head.appendChild(link);
+            } 
+            else {
+                let darkSheet = document.getElementById('dark-sheet');
+                darkSheet.parentElement.removeChild(darkSheet);
+            }
+            this.darkMode = darkMode;
+            try {
+                window.localStorage.setItem("darkMode", this.darkMode);
+            } catch (e) {
+                //ignore
+            }
+        },
+        toggleDarkMode() {
+            this.switchMode(!this.darkMode);
+        }
+    }
+    
     $('.js-expand-signatories').on('click', evt => {
         evt.preventDefault();
         if (expanded) {
@@ -22,20 +57,9 @@ $(() => {
         expanded = !expanded;
     });
 
-    let darkMode = false;
-
+    switcher.init();
+    
     $('.color-mode-toggle').on('click', evt => {
-        if (!darkMode) {
-            let link = document.createElement('link');
-            link.href = 'stylesheets/dark.css';
-            link.rel = 'stylesheet';
-            link.id = 'dark-sheet';
-            document.head.appendChild(link);
-        }
-        else {
-            let darkSheet = document.getElementById('dark-sheet');
-            darkSheet.parentElement.removeChild(darkSheet);
-        }
-        darkMode = !darkMode;
+        switcher.toggleDarkMode();
     });
 });


### PR DESCRIPTION
The state for the dark mode is now sticky and would persist between reloads. The state is saved in local storage. If local storage is not available, it's assumed to be "off" starts in light mode.