### PR TITLE
fix Signatory model created_at, updated_at types

### DIFF
--- a/models/signatory.ts
+++ b/models/signatory.ts
@@ -4,8 +4,8 @@ export class Signatory extends BaseModel {
     id: number;
     se_acct_id: number;
     display_name: string;
-    created_at: string;
-    updated_at: string;
+    created_at: Date;
+    updated_at: Date;
 
     static get tableName() {
         return 'signatories';

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -19,7 +19,7 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
         ).map((signatory: Signatory) => {
             return {
                 ...signatory,
-                created_at: new Date(signatory.created_at) >= minimumDate ? new Date(signatory.created_at) : minimumDate,
+                created_at: signatory.created_at >= minimumDate ? signatory.created_at : minimumDate,
                 original_created_at: signatory.created_at
             }
         });


### PR DESCRIPTION
This PR fixes the types of the `Signatory` model's `created_at` and `updated_at` properties + removes unnecessary reconstruction of the `created_at` property in the dashboard route.