### PR TITLE
/sign and /auth-redirect routes improvements

### DIFF
--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -1,5 +1,10 @@
 import * as et from 'express';
 
+interface SignRequestBody {
+    display_name?: string;
+    letter?: string;
+}
+
 interface ResponseWithLayout extends et.Response {
     statusCode: number;
 

--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -1,4 +1,10 @@
 import * as et from 'express';
+import type { ParsedQs } from 'qs';
+
+interface AuthRedirectRequestQs extends ParsedQs {
+    code: string;
+    state: string;
+}
 
 interface SignRequestBody {
     display_name?: string;

--- a/helpers/auth.ts
+++ b/helpers/auth.ts
@@ -4,7 +4,7 @@ import type { Signatory } from '../models/signatory';
 /**
  * Builds the URL for requesting the Stack Exchange's oauth endpoint
  */
-export const getAuthRedirectURL = (
+export const getAuthURL = (
     config: Config,
     signatory: Signatory,
     letter: string

--- a/helpers/auth.ts
+++ b/helpers/auth.ts
@@ -1,0 +1,24 @@
+import type { Config } from '../config/configuration';
+import type { Signatory } from '../models/signatory';
+
+/**
+ * Builds the URL for requesting the Stack Exchange's oauth endpoint
+ */
+export const getAuthRedirectURL = (
+    config: Config,
+    signatory: Signatory,
+    letter: string
+) => {
+    const client_id = config.getSiteSetting('clientId');
+    const redirect_uri = config.getSiteSetting('redirectUri');
+
+    const url = new URL('https://stackexchange.com/oauth');
+    url.search = new URLSearchParams({
+        client_id,
+        redirect_uri,
+        scope: '',
+        state: `${signatory.id}|${letter}`,
+    }).toString();
+
+    return url.toString();
+};

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -7,7 +7,7 @@ import { Signatory } from '../models/signatory';
 import type { AuthRedirectRequestQs, ResponseWithLayout, SignRequestBody } from '../definitions';
 import crypto from 'crypto';
 import type { Debugger } from 'debug'
-import { getAuthRedirectURL } from '../helpers/auth';
+import { getAuthURL } from '../helpers/auth';
 const fetch = require('node-fetch');
 const router = express.Router(); // eslint-disable-line new-cap
 
@@ -50,7 +50,7 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
             return;
         }
         const signatory: Signatory = await <Promise<Signatory>>Signatory.create({ display_name: displayName, letter });
-        res.redirect(getAuthRedirectURL(config, signatory, letter));
+        res.redirect(getAuthURL(config, signatory, letter));
     });
 
     router.get('/auth-redirect', async (req: express.Request<any, any, any, AuthRedirectRequestQs>, res: ResponseWithLayout) => {

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -4,7 +4,7 @@ import { URLSearchParams } from 'url';
 import { render, error } from '../render_helpers';
 import config from '../config/config';
 import { Signatory } from '../models/signatory';
-import { ResponseWithLayout } from '../definitions';
+import type { ResponseWithLayout, SignRequestBody } from '../definitions';
 import crypto from 'crypto';
 import type { Debugger } from 'debug'
 const fetch = require('node-fetch');
@@ -37,7 +37,7 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
         res.redirect('/icon.png');
     });
 
-    router.post('/sign', async (req: express.Request, res: ResponseWithLayout) => {
+    router.post('/sign', async (req: express.Request<any, any, SignRequestBody>, res: ResponseWithLayout) => {
         const displayName = req.body['display_name'] || null;
         const letter = req.body['letter'] || 'main';
         if (displayName.indexOf('♦') !== -1) {

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -7,6 +7,7 @@ import { Signatory } from '../models/signatory';
 import type { AuthRedirectRequestQs, ResponseWithLayout, SignRequestBody } from '../definitions';
 import crypto from 'crypto';
 import type { Debugger } from 'debug'
+import { getAuthRedirectURL } from '../helpers/auth';
 const fetch = require('node-fetch');
 const router = express.Router(); // eslint-disable-line new-cap
 
@@ -49,7 +50,7 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
             return;
         }
         const signatory: Signatory = await <Promise<Signatory>>Signatory.create({ display_name: displayName, letter });
-        res.redirect(`https://stackexchange.com/oauth?client_id=${config.getSiteSetting('clientId')}&scope=&state=${signatory.id}|${letter}&redirect_uri=${config.getSiteSetting('redirectUri')}`);
+        res.redirect(getAuthRedirectURL(config, signatory, letter));
     });
 
     router.get('/auth-redirect', async (req: express.Request<any, any, any, AuthRedirectRequestQs>, res: ResponseWithLayout) => {

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -4,7 +4,7 @@ import { URLSearchParams } from 'url';
 import { render, error } from '../render_helpers';
 import config from '../config/config';
 import { Signatory } from '../models/signatory';
-import type { ResponseWithLayout, SignRequestBody } from '../definitions';
+import type { AuthRedirectRequestQs, ResponseWithLayout, SignRequestBody } from '../definitions';
 import crypto from 'crypto';
 import type { Debugger } from 'debug'
 const fetch = require('node-fetch');
@@ -52,9 +52,9 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
         res.redirect(`https://stackexchange.com/oauth?client_id=${config.getSiteSetting('clientId')}&scope=&state=${signatory.id}|${letter}&redirect_uri=${config.getSiteSetting('redirectUri')}`);
     });
 
-    router.get('/auth-redirect', async (req: express.Request, res: ResponseWithLayout) => {
-        const code = req.query['code'] as string;
-        const state = req.query['state'] as string;
+    router.get('/auth-redirect', async (req: express.Request<any, any, any, AuthRedirectRequestQs>, res: ResponseWithLayout) => {
+        const code = req.query['code'];
+        const state = req.query['state'];
         const signatoryId = state.split('|')[0];
         const letter = state.split('|')[1];
 


### PR DESCRIPTION
This PR includes:
- type definitions for the /sign route request body and the /auth-redirect route request parsed query string;
- `getAuthURL` helper for reliable building of the SE OAuth URL;