### PR TITLE
Dark mode toggle button icons

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -1,15 +1,14 @@
 $(() => {
-  const darkModeKey = 'darkMode';
 
-  let expanded = false;
-  let text;
-
+  // Switcher component
   const switcher = {
+    darkModeKey: 'darkMode',
     darkMode: window.matchMedia('(prefers-color-scheme:dark)').matches,
+
     init() {
       // Fetch dark mode preference from local storage
       try {
-        const stored = window.localStorage.getItem(darkModeKey);
+        const stored = window.localStorage.getItem(this.darkModeKey);
 
         if (stored !== null) {
           const darkMode = stored === 'true';
@@ -20,10 +19,13 @@ $(() => {
       }
 
       // Add event listener to toggle dark mode
-      $(document).on('click', '.color-mode-toggle', () => {
-        this.toggleDarkMode();
+      document.addEventListener('click', evt => {
+        if (evt.target?.classList.contains('color-mode-toggle')) {
+          this.toggleDarkMode();
+        }
       });
     },
+
     switchMode(darkMode) {
       const link = document.querySelector('link[href*="dark.css"]');
 
@@ -35,36 +37,57 @@ $(() => {
 
       // Save dark mode preference to local storage
       try {
-        window.localStorage.setItem(darkModeKey, this.darkMode);
+        window.localStorage.setItem(this.darkModeKey, this.darkMode);
       } catch (e) {
         // ignore
       }
     },
+
     toggleDarkMode() {
       this.switchMode(!this.darkMode);
     }
   };
-
   switcher.init();
 
-  // Toggle signatory panel
-  $('.js-expand-signatories').on('click', evt => {
-    if (expanded) {
-      $('.signatory-panel, .shadow').css({
-        'max-height': '30em',
-        'overflow-y': 'scroll'
+  // Panel component
+  const panel = {
+    panelElem: document.querySelector('.signatory-panel'),
+    toggleElem: document.querySelector('.js-expand-signatories'),
+
+    togglePanel() {
+      const { panelElem, toggleElem } = this;
+
+      // Get state of panel from the existence of "expanded" class
+      const isExpanded = panelElem.classList.contains('expanded');
+
+      // Toggle the panel "expanded" class
+      panelElem.classList.toggle('expanded', !isExpanded);
+
+      // Toggle the link text
+      toggleElem.innerHTML = isExpanded ? toggleElem.dataset.originalHtml : 'Contract <i class="fa-arrow-up fas"></i>';
+    },
+
+    init() {
+      const { panelElem, toggleElem } = this;
+
+      // Both panel or toggle element must exist
+      if (!panelElem || !toggleElem) {
+        console.error('Missing panel or toggle element');
+        return;
+      }
+
+      // Store original text and signatory count
+      toggleElem.dataset.originalHtml = toggleElem.innerHTML;
+
+      // Not necessary at the moment, but could be useful in the future
+      toggleElem.dataset.count = panelElem.children.length;
+      panelElem.dataset.count = panelElem.children.length;
+
+      // Add event listener to link
+      toggleElem.addEventListener('click', evt => {
+        this.togglePanel();
       });
-      $(evt.target).html(text);
     }
-    else {
-      text = $(evt.target).html();
-      $('.signatory-panel, .shadow').css({
-        'max-height': 'unset',
-        'overflow-y': 'hidden'
-      });
-      $(evt.target).html('Contract &uarr;');
-    }
-    expanded = !expanded;
-    return false;
-  });
+  };
+  panel.init();
 });

--- a/public/stylesheets/dark.scss
+++ b/public/stylesheets/dark.scss
@@ -12,7 +12,7 @@ body {
 
 main {
     background: #333;
-    color: #CCC;
+    color: #ccc;
 }
 
 aside {
@@ -36,7 +36,7 @@ aside.danger {
 }
 
 section.signatories h5 {
-    color: #AAA;
+    color: #aaa;
 }
 
 .signatory-panel p:hover {
@@ -72,7 +72,7 @@ a {
 }
 
 hr {
-    border-top: 1px solid rgba(255, 255, 255, .1)
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 section.signatories .expand a {

--- a/public/stylesheets/dark.scss
+++ b/public/stylesheets/dark.scss
@@ -6,8 +6,16 @@ body {
 }
 
 .color-mode-toggle {
-    background: white;
-    border: 1px solid #444;
+    background: #eee;
+    color: #222;
+    border: none;
+
+    .fa-sun {
+        display: block;
+    }
+    .fa-moon {
+        display: none;
+    }
 }
 
 main {

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -4,8 +4,8 @@
 body {
     --header-height: 58px;
     padding-top: var(--header-height);
-    background: #EEE;
-    font-family: 'Open Sans', sans-serif;
+    background: #eee;
+    font-family: "Open Sans", sans-serif;
     font-size: 11pt;
 }
 
@@ -34,9 +34,10 @@ p {
     line-height: 1.6;
 }
 
-ol, ul {
+ol,
+ul {
     margin-bottom: 1.5rem;
-    
+
     li {
         margin-bottom: 0.3em;
         line-height: 1.35;
@@ -57,7 +58,7 @@ hr {
 
 /* Offset anchors for fixed header https://stackoverflow.com/a/24298427 */
 [id]::before {
-    content: '';
+    content: "";
     display: block;
     height: calc(var(--header-height) + 1.5rem);
     /* fixed header height + padding */
@@ -76,19 +77,19 @@ header {
     height: var(--header-height);
     overflow: hidden;
     background-color: #17a7db;
-    background-image: url('https://cdn.sstatic.net/Sites/stackexchangemeta/img/background.svg');
+    background-image: url("https://cdn.sstatic.net/Sites/stackexchangemeta/img/background.svg");
     background-position: center left;
     background-repeat: repeat;
     background-size: auto;
 
     .header-inner {
         background-color: transparent;
-        background-image: url('https://cdn.sstatic.net/Sites/stackexchangemeta/img/icon-cloud-footer@2.png');
+        background-image: url("https://cdn.sstatic.net/Sites/stackexchangemeta/img/icon-cloud-footer@2.png");
         background-position: bottom right;
         background-repeat: no-repeat;
         background-size: 475px;
         padding: 1.2rem 2rem;
-        font-family: 'Montserrat', sans-serif;
+        font-family: "Montserrat", sans-serif;
         color: white;
         display: flex;
         justify-content: space-between;
@@ -124,7 +125,7 @@ header {
 }
 
 .content-container:after {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
@@ -136,13 +137,13 @@ header {
 
 aside {
     color: #737063;
-    background: #FFF8DC;
+    background: #fff8dc;
     padding: 1.7em 2em 1.7em;
     display: flex;
     align-items: center;
     border-bottom: 1px solid #e6dfc6;
 
-    &>i:first-child {
+    & > i:first-child {
         margin-right: 1rem;
     }
 
@@ -203,7 +204,7 @@ label {
 
 section.signatories {
     h5 {
-        font-family: 'Open Sans';
+        font-family: "Open Sans";
         font-style: italic;
         color: #555;
         margin: 0.5em 0 1em 0;
@@ -215,7 +216,7 @@ section.signatories {
 
         a {
             display: inline-block;
-            border: 1px solid #DDD;
+            border: 1px solid #ddd;
             border-top: 1px solid white;
             border-bottom-left-radius: 4px;
             border-bottom-right-radius: 4px;
@@ -230,7 +231,7 @@ section.signatories {
     grid-template-columns: repeat(2, 1fr);
     max-height: 25em;
     overflow-y: scroll;
-    border-bottom: 1px solid #DDD;
+    border-bottom: 1px solid #ddd;
 
     &.expanded {
         max-height: unset;
@@ -264,7 +265,7 @@ section.signatories {
         min-width: 0;
 
         &:hover {
-            background: #EEE;
+            background: #eee;
         }
     }
 }
@@ -283,7 +284,6 @@ section.signing {
 }
 
 section.faq {
-
     h4 {
         margin-top: 1.3em;
         margin-bottom: 1rem;
@@ -309,7 +309,7 @@ section.faq {
         }
     }
 
-    .content-container>aside {
+    .content-container > aside {
         display: none;
     }
 }

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -49,11 +49,24 @@ hr {
 }
 
 .color-mode-toggle {
-    background: #222;
-    border: 1px solid white;
-    height: 20px;
-    width: 20px;
-    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 24px;
+    width: 24px;
+    background: #333;
+    color: white;
+    border: none;
+    border-radius: 50%;
+
+    .fa-sun {
+        display: none;
+        font-size: 11pt;
+    }
+    .fa-moon {
+        display: block;
+        font-size: 9pt;
+    }
 }
 
 /* Offset anchors for fixed header https://stackoverflow.com/a/24298427 */
@@ -73,9 +86,13 @@ header {
     left: 0;
     right: 0;
     z-index: 100;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     width: 100%;
     height: var(--header-height);
     overflow: hidden;
+
     background-color: #17a7db;
     background-image: url("https://cdn.sstatic.net/Sites/stackexchangemeta/img/background.svg");
     background-position: center left;
@@ -83,17 +100,19 @@ header {
     background-size: auto;
 
     .header-inner {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        height: 100%;
+        padding: 0.5rem 2rem;
+        font-family: "Montserrat", sans-serif;
+        color: white;
+
         background-color: transparent;
         background-image: url("https://cdn.sstatic.net/Sites/stackexchangemeta/img/icon-cloud-footer@2.png");
         background-position: bottom right;
         background-repeat: no-repeat;
         background-size: 475px;
-        padding: 1.2rem 2rem;
-        font-family: "Montserrat", sans-serif;
-        color: white;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
 
         .header-nav {
             text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
@@ -136,23 +155,22 @@ header {
 }
 
 aside {
-    color: #737063;
-    background: #fff8dc;
-    padding: 1.7em 2em 1.7em;
     display: flex;
     align-items: center;
+    padding: 1.7em 2em 1.7em;
     border-bottom: 1px solid #e6dfc6;
+    font-size: 10pt;
+    color: #737063;
+    background: #fff8dc;
 
     & > i:first-child {
         margin-right: 1rem;
+        font-size: 1rem;
     }
 
-    p {
-        font-size: 0.9em;
-
-        &:last-child {
-            margin-bottom: 0;
-        }
+    & > :last-child,
+    p:last-child {
+        margin-bottom: 0;
     }
 }
 

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -84,7 +84,7 @@ header {
     .header-inner {
         background-color: transparent;
         background-image: url('https://cdn.sstatic.net/Sites/stackexchangemeta/img/icon-cloud-footer@2.png');
-        background-position: bottom -68px right;
+        background-position: bottom right;
         background-repeat: no-repeat;
         background-size: 475px;
         padding: 1.2rem 2rem;

--- a/views/common/error.ejs
+++ b/views/common/error.ejs
@@ -1,7 +1,7 @@
 <aside class="danger mt-4">
     <i class="fas fa-exclamation-triangle"></i>
     <div>
-        Your signature could not be processed at this time. Please go back and try again.
+        <p>Your signature could not be processed at this time. Please go back and try again.</p>
         <p><%= error %></p>
     </div>
 </aside>

--- a/views/dashboard/signatories.ejs
+++ b/views/dashboard/signatories.ejs
@@ -22,6 +22,6 @@
         <% }); %>
     </div>
     <div class="expand">
-        <a class="js-expand-signatories" href="#">Expand all <%= signatories.length %>&darr;</a>
+        <a class="js-expand-signatories" href="#signatures">Expand all <%= signatories.length %> <i class="fa-arrow-down fas"></i></a>
     </div>
 </section>

--- a/views/dashboard/signing.ejs
+++ b/views/dashboard/signing.ejs
@@ -17,23 +17,23 @@
 
         <aside class="danger mt-4">
             <i class="fas fa-exclamation-triangle"></i>
-            <p>
+            <div>
                 When you click Sign, you will be taken to authenticate with your Stack&nbsp;Exchange account. This
                 allows us to make sure
                 everyone is only able to sign once. Once authentication is complete, your access token is discarded and
                 the letter has no possible access to your
                 account.
-            </p>
+            </div>
         </aside>
         
         <aside class="mt-2">
             <i class="fas fa-info-circle"></i>
-            <p>
+            <div>
                 If you're a moderator or employee, your signature will have a ♦ shown next to it automatically. If
                 you're a
                 former moderator or former employee, and would like a ◊, please contact <a
                     href="https://chat.stackexchange.com/users/490835/mousetail">Mousetail</a>.
-            </p>
+            </div>
         </aside>
     </form>
 </section>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -52,27 +52,27 @@
                     </li>
                 </ul>
             </nav>
-            <button type="button" class="color-mode-toggle" title="Toggle light/dark mode"></button>
+            <button type="button" class="color-mode-toggle" title="Toggle light/dark mode"><i class="fa-sun fas"></i><i class="fa-moon fas"></i></button>
         </div>
     </header>
     <div class="content-container col-12 col-xl-6 col-lg-8 col-md-10 mx-auto">
         <aside>
             <i class="fas fa-info-circle"></i>
-            <p>
+            <div>
                 What follows is an open letter to Stack&nbsp;Overflow, Inc., from some of the remaining moderators
                 there, detailing a strike.
                 While it was catalyzed by recent events, it's not solely about them - it's more generally about the
                 trend of implementing harmful changes that Stack&nbsp;Overflow, Inc. has been performing lately.
                 This letter is signed by a number of moderators and curators already, and you're welcome to sign in
                 support - please see the bottom of the page.
-            </p>
+            </div>
         </aside>
         <!--<aside class="danger">
             <i class="fas fa-exclamation-triangle"></i>
-            <p>
-                Just in case it's not clear: <strong>we're not Stack&nbsp;Exchange</strong>. This is not an official position of the company, and the sentiments
-                expressed herein are not those of the company.
-            </p>
+            <div>
+                Just in case it's not clear: <strong>we're not Stack&nbsp;Exchange</strong>. This is not an official
+                position of the company, and the sentiments expressed herein are not those of the company.
+            </div>
         </aside>-->
         <main>
             <%- content %>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -17,8 +17,8 @@
         crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:500|Open+Sans:400,400i,600|Fira+Sans&display=swap"
         rel="stylesheet" />
-    <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?2" />
-    <link rel="stylesheet" type="text/css" href="/stylesheets/dark.css?2" media="(prefers-color-scheme:dark)" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?3" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/dark.css?3" media="(prefers-color-scheme:dark)" />
 
     <script type="application/javascript" src="https://code.jquery.com/jquery-3.4.1.min.js"
         integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>


### PR DESCRIPTION
- Header inner background align bottom looks better
  Current:
  ![Screenshot_2023-06-08_100603](https://github.com/mousetail/openletter/assets/845988/8433b6fc-e45e-49ed-b4c6-a1082f43f049)
  Proposed:
  ![Screenshot_2023-06-08_100644](https://github.com/mousetail/openletter/assets/845988/0125c8c8-35a9-4826-a1f5-258793f830de)

- Add icons to theme toggle for accessibility reasons
  ![Screenshot_2023-06-08_110634](https://github.com/mousetail/openletter/assets/845988/397ea81c-2543-436c-a730-5715aa0413a4) ![Screenshot_2023-06-08_110630](https://github.com/mousetail/openletter/assets/845988/394500fb-cb7d-4c66-9803-27f57967895e) 

- Use proper icons for panel toggle
  ![Screenshot_2023-06-08_120654](https://github.com/mousetail/openletter/assets/845988/de618e22-9e36-4618-b547-5d64e0e2c06a) ![Screenshot_2023-06-08_120605](https://github.com/mousetail/openletter/assets/845988/5277b35e-c8be-4ae9-a983-e2e33b0b2c34)

- Panel toggle link to jump to start of signatures list on click
- Rewrite jQuery to JS