### PR TITLE
Fix dark mode switch button

### DIFF
--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -1,9 +1,18 @@
 import * as et from 'express';
 import type { ParsedQs } from 'qs';
 
+type SortOrder = 'asc' | 'desc';
+
+type SortType = 'alpha' | 'date_signed';
+
 interface AuthRedirectRequestQs extends ParsedQs {
     code: string;
     state: string;
+}
+
+interface MainRequestQs extends ParsedQs {
+    order?: SortOrder;
+    sort?: SortType;
 }
 
 interface SignRequestBody {

--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -15,6 +15,11 @@ interface MainRequestQs extends ParsedQs {
     sort?: SortType;
 }
 
+interface SaveSortRequestBody {
+    order?: SortOrder;
+    sort?: SortType;
+}
+
 interface SignRequestBody {
     display_name?: string;
     letter?: string;

--- a/definitions.d.ts
+++ b/definitions.d.ts
@@ -3,7 +3,7 @@ import type { ParsedQs } from 'qs';
 
 type SortOrder = 'asc' | 'desc';
 
-type SortType = 'alpha' | 'date_signed';
+type SortType = 'alpha' | 'date_signed' | 'random';
 
 interface AuthRedirectRequestQs extends ParsedQs {
     code: string;

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -18,12 +18,13 @@ $(() => {
         // ignore
       }
 
-      // Add event listener to toggle dark mode
-      document.addEventListener('click', evt => {
-        if (evt.target?.classList.contains('color-mode-toggle')) {
-          this.toggleDarkMode();
-        }
-      });
+      const switchBtn = document.querySelector('.color-mode-toggle');
+
+      if(switchBtn) {
+        switchBtn.addEventListener('click', () => {
+            this.toggleDarkMode();
+          });
+      }
     },
 
     switchMode(darkMode) {
@@ -31,6 +32,12 @@ $(() => {
 
       if (link) {
         link.disabled = !darkMode;
+
+        if(darkMode) {
+            link.removeAttribute('media');
+        } else {
+            link.setAttribute('media', '(prefers-color-scheme:dark)');
+        }
       }
 
       this.darkMode = darkMode;

--- a/public/stylesheets/dark.scss
+++ b/public/stylesheets/dark.scss
@@ -51,6 +51,13 @@ section.signatories h5 {
     color: #aaa;
 }
 
+.signatory-sort > form {
+    select {
+        background-color: #333;
+        color: #ddd;
+    }
+}
+
 .signatory-panel p:hover {
     background: #444;
 }

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -236,7 +236,7 @@ section.signatories {
         font-family: "Open Sans";
         font-style: italic;
         color: #555;
-        margin: 0.5em 0 1em 0;
+        margin: 0;
     }
 
     .expand {
@@ -252,6 +252,30 @@ section.signatories {
             margin: -1px auto 0 auto;
             padding: 0.5rem 2rem;
         }
+    }
+}
+
+.signatory-header {
+    align-items: end;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin: 0.5em 0 1em 0;
+}
+
+.signatory-sort > form {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: end;
+
+    legend {
+        font-size: 10pt;
+        margin: 0 0 0 5px;
+    }
+
+    select {
+        border: none;
+        color: #555;
     }
 }
 

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -39,7 +39,7 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
         });
         const etag = crypto.createHash('sha256').update(`${config.getSiteSetting('letterVersion')}-${signatories.length}`).digest('hex');
         res.setHeader('ETag', etag);
-        render(req, res, 'dashboard/dash', { signatories }, { pool });
+        render(req, res, 'dashboard/dash', { order, sort, signatories }, { pool });
     });
 
 

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -4,7 +4,15 @@ import { URLSearchParams } from 'url';
 import { render, error } from '../render_helpers';
 import config from '../config/config';
 import { Signatory } from '../models/signatory';
-import type { AuthRedirectRequestQs, MainRequestQs, SortType, ResponseWithLayout, SignRequestBody } from '../definitions';
+import type {
+    AuthRedirectRequestQs,
+    MainRequestQs,
+    SortType,
+    ResponseWithLayout,
+    SignRequestBody,
+    SaveSortRequestBody,
+    SortOrder
+} from '../definitions';
 import crypto from 'crypto';
 import type { Debugger } from 'debug'
 import { getAuthURL } from '../helpers/auth';
@@ -15,7 +23,7 @@ const minimumDate = new Date('2023-06-05T04:00:00Z')
 
 export default (pool: mt.Pool, _log: Debugger): express.Router => {
     router.get('/', async (req: express.Request<any, any, any, MainRequestQs>, res: ResponseWithLayout) => {
-        const { order = 'asc', sort = 'alpha' } = req.query;
+        const { order = 'asc', sort = 'alpha' } = req.cookies;
 
         const builder = Signatory.where(`se_acct_id IS NOT NULL AND letter = 'main'`);
 
@@ -49,6 +57,17 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
 
     router.get('/favicon.ico', async (_req: express.Request, res: ResponseWithLayout) => {
         res.redirect('/icon.png');
+    });
+
+    router.post('/save-sort', async (req: express.Request<any, any, SaveSortRequestBody>, res: express.Response) => {
+        const { order = 'asc', sort = 'alpha' } = req.body;
+
+        const availableSortOrders: SortOrder[] = ['asc', 'desc'];
+        const availableSortTypes: SortType[] = ['alpha', 'date_signed'];
+
+        res.cookie('order', availableSortOrders.includes(order) ? order : 'asc');
+        res.cookie('sort', availableSortTypes.includes(sort) ? sort : 'alpha');
+        res.redirect( '/' );
     });
 
     router.post('/sign', async (req: express.Request<any, any, SignRequestBody>, res: ResponseWithLayout) => {

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -23,18 +23,19 @@ const minimumDate = new Date('2023-06-05T04:00:00Z')
 
 export default (pool: mt.Pool, _log: Debugger): express.Router => {
     router.get('/', async (req: express.Request<any, any, any, MainRequestQs>, res: ResponseWithLayout) => {
-        const { order = 'asc', sort = 'alpha' } = req.cookies;
+        const { order = 'asc', sort = 'random' } = req.cookies;
 
         const builder = Signatory.where(`se_acct_id IS NOT NULL AND letter = 'main'`);
 
         const sortQ: Record<SortType, string> = {
             'alpha': 'is_moderator DESC, is_former_moderator DESC, display_name',
-            'date_signed': 'is_moderator DESC, is_former_moderator DESC, created_at'
+            'date_signed': 'is_moderator DESC, is_former_moderator DESC, created_at',
+            'random': 'is_moderator DESC, is_former_moderator DESC, RAND()',
         };
 
         const entities = await builder.order(
-            sort in sortQ ? sortQ[sort] : sortQ.alpha,
-            order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC',
+            sort in sortQ ? sortQ[sort] : sortQ.random,
+            sort === 'random' ? '' : order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC',
             true
         ).get()
 
@@ -60,14 +61,14 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
     });
 
     router.post('/save-sort', async (req: express.Request<any, any, SaveSortRequestBody>, res: express.Response) => {
-        const { order = 'asc', sort = 'alpha' } = req.body;
+        const { order = 'asc', sort = 'random' } = req.body;
 
         const availableSortOrders: SortOrder[] = ['asc', 'desc'];
-        const availableSortTypes: SortType[] = ['alpha', 'date_signed'];
+        const availableSortTypes: SortType[] = ['alpha', 'date_signed', 'random'];
 
         res.cookie('order', availableSortOrders.includes(order) ? order : 'asc');
-        res.cookie('sort', availableSortTypes.includes(sort) ? sort : 'alpha');
-        res.redirect( '/' );
+        res.cookie('sort', availableSortTypes.includes(sort) ? sort : 'random');
+        res.redirect('/');
     });
 
     router.post('/sign', async (req: express.Request<any, any, SignRequestBody>, res: ResponseWithLayout) => {

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -66,8 +66,8 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
         const availableSortOrders: SortOrder[] = ['asc', 'desc'];
         const availableSortTypes: SortType[] = ['alpha', 'date_signed', 'random'];
 
-        res.cookie('order', availableSortOrders.includes(order) ? order : 'asc');
-        res.cookie('sort', availableSortTypes.includes(sort) ? sort : 'random');
+        res.cookie('order', availableSortOrders.includes(order) ? order : 'asc', { httpOnly: true });
+        res.cookie('sort', availableSortTypes.includes(sort) ? sort : 'random', { httpOnly: true });
         res.redirect('/');
     });
 

--- a/views/dashboard/signatories.ejs
+++ b/views/dashboard/signatories.ejs
@@ -1,6 +1,23 @@
 <section class="signatories" id="signatures">
-    <h5>Signed,</h5>
-
+    <div class="signatory-header">
+        <h5>Signed,</h5>
+        <div class="signatory-sort border rounded px-1">
+            <form name="signatory-sort" method="post" action="/save-sort">
+                <select name="sort">
+                    <option value="" disabled>Sort By</option>
+                    <option value="alpha" <%= sort === 'alpha' ? 'selected' : '' %>>Display name</option>
+                    <option value="date_signed" <%= sort === 'date_signed' ? 'selected' : '' %>>Date signed</option>
+                    <option value="random" <%= sort === 'random' ? 'selected' : '' %>>Randomized</option>
+                </select>
+                <select name="order">
+                    <option value="" disabled>Order</option>
+                    <option value="asc" <%= order === 'asc' ? 'selected' : '' %>>Ascending</option>
+                    <option value="desc"<%= order === 'desc' ? 'selected' : '' %>>Descending</option>
+                </select>
+                <button type="submit" class="btn btn-link btn-sm px-1">Save</button>
+            </form>
+        </div>
+    </div>
     <div class="signatory-panel">
         <% signatories.forEach(sig=> { %>
             <p>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -39,16 +39,16 @@
             <nav class="header-nav">
                 <ul>
                     <li>
-                        <a href="/?sort=<%= sort %>&order=<%= order %>#letter">Letter</a>
+                        <a href="/#letter">Letter</a>
                     </li>
                     <li>
-                        <a href="/?sort=<%= sort %>&order=<%= order %>#signatures">Signatures</a>
+                        <a href="/#signatures">Signatures</a>
                     </li>
                     <li>
-                        <a href="/?sort=<%= sort %>&order=<%= order %>#sign">Sign</a>
+                        <a href="/#sign">Sign</a>
                     </li>
                     <li>
-                        <a href="/?sort=<%= sort %>&order=<%= order %>#faq">FAQ</a>
+                        <a href="/#faq">FAQ</a>
                     </li>
                 </ul>
             </nav>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -18,7 +18,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:500|Open+Sans:400,400i,600|Fira+Sans&display=swap"
         rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?5" />
-    <link rel="stylesheet" type="text/css" href="/stylesheets/dark.css?4" media="(prefers-color-scheme:dark)" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/dark.css?5" media="(prefers-color-scheme:dark)" />
 
     <script type="application/javascript" src="https://code.jquery.com/jquery-3.4.1.min.js"
         integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -39,16 +39,16 @@
             <nav class="header-nav">
                 <ul>
                     <li>
-                        <a href="/#letter">Letter</a>
+                        <a href="/?sort=<%= sort %>&order=<%= order %>#letter">Letter</a>
                     </li>
                     <li>
-                        <a href="/#signatures">Signatures</a>
+                        <a href="/?sort=<%= sort %>&order=<%= order %>#signatures">Signatures</a>
                     </li>
                     <li>
-                        <a href="/#sign">Sign</a>
+                        <a href="/?sort=<%= sort %>&order=<%= order %>#sign">Sign</a>
                     </li>
                     <li>
-                        <a href="/#faq">FAQ</a>
+                        <a href="/?sort=<%= sort %>&order=<%= order %>#faq">FAQ</a>
                     </li>
                 </ul>
             </nav>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -28,7 +28,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
-    <script type="application/javascript" src="/javascripts/application.js?1"></script>
+    <script type="application/javascript" src="/javascripts/application.js?2"></script>
 
     <link rel="icon" href="icon.png">
 </head>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -17,7 +17,7 @@
         crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:500|Open+Sans:400,400i,600|Fira+Sans&display=swap"
         rel="stylesheet" />
-    <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?4" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?5" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/dark.css?4" media="(prefers-color-scheme:dark)" />
 
     <script type="application/javascript" src="https://code.jquery.com/jquery-3.4.1.min.js"


### PR DESCRIPTION
This PR fixes dark mode switch button (requires resolution of #39). The issue was two-fold:
- setting a delegated event listener is unreliable now since the target might be the icon, and not the button itself;
- in Chrome, without removing the `media` attribute, the preloaded stylesheet doesn't apply regardless of whether it is enabled;