### PR TITLE
Add signatory breakdown to the dashboard

### DIFF
--- a/helpers/signatories.ts
+++ b/helpers/signatories.ts
@@ -1,0 +1,33 @@
+import type { Signatory } from "../models/signatory";
+
+export interface SignatoryBreakdown {
+    current_mods: number;
+    former_mods: number;
+    regular_users: number;
+}
+
+/**
+ * Builds {@link SignatoryBreakdown} from a list of {@link Signatory}-like objects
+ * @param signatories list of {@link Signatory}-like objects
+ */
+export const getSignatoryBreakdown = (
+    signatories: Pick<Signatory, 'is_moderator'|'is_former_moderator'>[]
+): SignatoryBreakdown => {
+    const breakdown: SignatoryBreakdown = {
+        current_mods: 0,
+        former_mods: 0,
+        regular_users: 0,
+    };
+
+    for (const signatory of signatories) {
+        if(signatory.is_moderator) {
+            breakdown.current_mods += 1;
+        } else if (signatory.is_former_moderator) {
+            breakdown.former_mods += 1;
+        } else {
+            breakdown.regular_users += 1;
+        }
+    }
+
+    return breakdown;
+};

--- a/models/signatory.ts
+++ b/models/signatory.ts
@@ -4,6 +4,8 @@ export class Signatory extends BaseModel {
     id: number;
     se_acct_id: number;
     display_name: string;
+    is_former_moderator: number;
+    is_moderator: number;
     created_at: Date;
     updated_at: Date;
 

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -265,6 +265,10 @@ section.signatories {
     }
 }
 
+.signatory-breakdown {
+    margin-top: 1.5rem;
+}
+
 .signatory-panel {
     display: grid;
     grid-template-columns: repeat(2, 1fr);

--- a/routes/dashboard.ts
+++ b/routes/dashboard.ts
@@ -8,6 +8,7 @@ import type { AuthRedirectRequestQs, ResponseWithLayout, SignRequestBody } from 
 import crypto from 'crypto';
 import type { Debugger } from 'debug'
 import { getAuthURL } from '../helpers/auth';
+import { getSignatoryBreakdown } from '../helpers/signatories';
 const fetch = require('node-fetch');
 const router = express.Router(); // eslint-disable-line new-cap
 
@@ -24,9 +25,13 @@ export default (pool: mt.Pool, _log: Debugger): express.Router => {
                 original_created_at: signatory.created_at
             }
         });
+
         const etag = crypto.createHash('sha256').update(`${config.getSiteSetting('letterVersion')}-${signatories.length}`).digest('hex');
         res.setHeader('ETag', etag);
-        render(req, res, 'dashboard/dash', { signatories }, { pool });
+
+        const breakdown = getSignatoryBreakdown(signatories);
+
+        render(req, res, 'dashboard/dash', { breakdown, signatories }, { pool });
     });
 
 

--- a/views/dashboard/signatories.ejs
+++ b/views/dashboard/signatories.ejs
@@ -25,4 +25,11 @@
         <a class="js-expand-signatories" href="#signatures">Expand all <%= signatories.length %> <i
                     class="fa-arrow-down fas"></i></a>
     </div>
+
+    <p class="signatory-breakdown">
+        <strong>Total signed:</strong>
+        <%= breakdown.current_mods %> <%= pluralize("moderator", breakdown.current_mods) %>,
+        <%= breakdown.former_mods %> <%= pluralize("former moderator", breakdown.former_mods) %> & staff,
+        and <%= breakdown.regular_users %> <%= pluralize("regular user", breakdown.regular_users) %>.
+    </p>
 </section>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -13,7 +13,7 @@
         crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:500|Open+Sans:400,400i,600|Fira+Sans&display=swap"
         rel="stylesheet" />
-    <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?5" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/style.css?6" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/dark.css?5" media="(prefers-color-scheme:dark)" />
 
     <script type="application/javascript" src="https://code.jquery.com/jquery-3.4.1.min.js"


### PR DESCRIPTION
This PR adds signatory breakdown list (giant S-safe) to the dashboard. Closes #26.

![screenshot of the signatories panel with the breakdown list at the bottom stating "Total signed: 2 moderators, 1 former moderator & staff, and 1 regular user."](https://github.com/mousetail/openletter/assets/34833340/ed766019-dd36-4288-9325-38abc1e99a89)
