### PR TITLE
Sticky signatory collapse link to bottom of screen when panel is expanded

### DIFF
--- a/public/stylesheets/dark.scss
+++ b/public/stylesheets/dark.scss
@@ -87,12 +87,19 @@ section.signatories {
         }
     }
 
-    .expand-wrapper {
-        box-shadow: inset 0px 7px 5px -3px rgba(255, 255, 255, 0.1);
+    .signatory-component {
+        .panel-bottom {
+            box-shadow: inset 0px 7px 5px -3px rgba(255, 255, 255, 0.1);
+            background-color: #333; /* same as main */
 
-        a {
-            border-top: 1px solid #333;
-            background-color: #333;
+            &::before {
+                border-top-color: #ddd;
+            }
+
+            a {
+                border-top: 1px solid #333;
+                background-color: #333; /* same as main */
+            }
         }
     }
 }

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -97,12 +97,12 @@ aside {
     color: #737063;
     background: #fff8dc;
 
-    &>i:first-child {
+    & > i:first-child {
         margin-right: 1.2rem;
         font-size: 1.2rem;
     }
 
-    &> :last-child,
+    & > :last-child,
     p:last-child {
         margin-bottom: 0;
     }
@@ -120,7 +120,7 @@ aside {
         text-align: center;
         line-height: 1.4;
 
-        &>i:first-child {
+        & > i:first-child {
             margin-right: 0;
             margin-bottom: 0.8rem;
         }
@@ -279,20 +279,37 @@ section.signatories {
         }
     }
 
-    .expand-wrapper {
-        text-align: center;
-        font-weight: bold;
-        box-shadow: inset 0px 7px 5px -3px rgba(0, 0, 0, 0.1);
+    .signatory-component {
+        position: relative;
 
-        a {
-            display: inline-block;
-            border: 1px solid #ddd;
-            border-top: 1px solid white;
-            border-bottom-left-radius: 4px;
-            border-bottom-right-radius: 4px;
-            margin: -1px auto 0 auto;
-            padding: 0.5rem 2rem;
-            background: white;
+        .panel-bottom {
+            position: relative;
+            background: white; /* same as main */
+            text-align: center;
+            font-weight: bold;
+            box-shadow: inset 0px 7px 5px -3px rgba(0, 0, 0, 0.1);
+
+            &::before {
+                content: "";
+                position: absolute;
+                top: -1px;
+                left: 0;
+                right: 0;
+                height: 1px;
+                z-index: -1;
+                border-top: 1px solid #ddd;
+            }
+
+            a {
+                display: inline-block;
+                border: 1px solid #ddd;
+                border-top: 1px solid white;
+                border-bottom-left-radius: 4px;
+                border-bottom-right-radius: 4px;
+                margin: -1px auto 0 auto;
+                padding: 0.5rem 2rem;
+                background: white; /* same as main */
+            }
         }
     }
 
@@ -303,9 +320,17 @@ section.signatories {
                 pointer-events: all;
             }
         }
-        .signatory-panel {
-            max-height: unset;
-            overflow-y: hidden;
+        .signatory-component {
+            .signatory-panel {
+                max-height: unset;
+                overflow-y: hidden;
+            }
+            .panel-bottom {
+                position: sticky;
+                bottom: 0;
+                left: 0;
+                right: 0;
+            }
         }
     }
 }
@@ -333,7 +358,7 @@ section.signatories {
         grid-template-columns: repeat(5, 1fr);
     }
 
-    &>p {
+    & > p {
         display: block;
         transition: all 0.2s ease;
         padding: 0.5em;
@@ -399,6 +424,10 @@ footer {
 
     header {
         position: static;
+
+        .color-mode-toggle {
+            display: none;
+        }
     }
 
     section.signing {
@@ -408,31 +437,29 @@ footer {
     section.signatories {
         page-break-inside: avoid;
 
-        .signatory-panel {
-            grid-template-columns: repeat(4, 1fr) !important;
-            max-height: unset;
-            overflow-y: hidden;
-            border-bottom: none;
+        .signatory-component {
+            .signatory-panel {
+                grid-template-columns: repeat(4, 1fr) !important;
+                max-height: unset;
+                overflow-y: hidden;
+                border-bottom: none;
 
-            &>p {
-                page-break-inside: avoid;
+                & > p {
+                    page-break-inside: avoid;
+                }
             }
-        }
 
-        .expand {
-            display: none;
-
-            .js-expand-signatories {
+            .panel-bottom {
                 display: none;
             }
         }
     }
 
-    .content-container>aside {
+    .content-container > aside {
         display: none;
     }
-}
 
-.hidden {
-    visibility: hidden;
+    .print-hidden {
+        display: none !important;
+    }
 }

--- a/views/dashboard/signatories.ejs
+++ b/views/dashboard/signatories.ejs
@@ -1,34 +1,36 @@
 <section class="signatories" id="signatures">
     <div class="signatories-header">
         <h5>Signed,</h5>
-        <div class="sort-controls hidden">
+        <div class="sort-controls">
             <button id="sort-name" class="btn btn-sm">Name <i class="fa-arrow-down fas"></i></button>
             <button id="sort-date" class="btn btn-sm">Date <i class="fa-arrow-down fas"></i></button>
         </div>
     </div>
 
-    <div class="signatory-panel">
-        <% signatories.forEach(sig=> { %>
-        <p>
-            <a href="https://stackexchange.com/users/<%= sig.se_acct_id %>?tab=accounts" rel="noopener noreferrer"
-                target="_blank">
-                <%= sig.display_name %>
-                <% if (sig.is_moderator) { %>
-                    <span title="moderator or employee">⬧</span>
-                <% } %>
-                <% if (sig.is_former_moderator) { %>
-                    <span title="former moderator or former employee">⬨</span>
-                <% } %>
-            </a><br />
-            <small class="text-muted" data-modified-at="<%= sig.created_at %>"
-                data-original-created-at="<%= sig.original_created_at %>">
-                <%= strftime(new Date(Date.parse(sig.created_at)), '%b %e' ) %>
-            </small>
-        </p>
-        <% }); %>
-    </div>
-    <div class="expand-wrapper">
-        <a class="js-expand-signatories" href="#signatures">Expand all <%= signatories.length %> <i class="fa-arrow-down fas"></i></a>
+    <div class="signatory-component">
+        <div class="signatory-panel">
+            <% signatories.forEach(sig=> { %>
+            <p>
+                <a href="https://stackexchange.com/users/<%= sig.se_acct_id %>?tab=accounts" rel="noopener noreferrer"
+                    target="_blank">
+                    <%= sig.display_name %>
+                    <% if (sig.is_moderator) { %>
+                        <span title="moderator or employee">⬧</span>
+                    <% } %>
+                    <% if (sig.is_former_moderator) { %>
+                        <span title="former moderator or former employee">⬨</span>
+                    <% } %>
+                </a><br />
+                <small class="text-muted" data-modified-at="<%= sig.created_at %>"
+                    data-original-created-at="<%= sig.original_created_at %>">
+                    <%= strftime(new Date(Date.parse(sig.created_at)), '%b %e' ) %>
+                </small>
+            </p>
+            <% }); %>
+        </div>
+        <div class="panel-bottom print-hidden">
+            <a class="js-expand-signatories" href="#signatures">Expand all <%= signatories.length %> <i class="fa-arrow-down fas"></i></a>
+        </div>
     </div>
 
     <p class="signatory-breakdown">

--- a/views/dashboard/signing.ejs
+++ b/views/dashboard/signing.ejs
@@ -1,4 +1,4 @@
-<section class="signing my-5" id="sign">
+<section class="signing print-hidden my-5" id="sign">
     <form method="POST" action="/sign">
         <h1>Add your voice</h1>
         <p>

--- a/views/layouts/application.ejs
+++ b/views/layouts/application.ejs
@@ -18,7 +18,7 @@
                     <li><a href="/#faq">FAQ</a></li>
                 </ul>
             </nav>
-            <button type="button" class="color-mode-toggle" title="Toggle light/dark mode">
+            <button type="button" class="color-mode-toggle print-hidden" title="Toggle light/dark mode">
                 <i class="fa-sun fas"></i><i class="fa-moon fas"></i>
             </button>
         </div>


### PR DESCRIPTION
Since the list is so long, if the collapse link is below the viewport, sticky it to the bottom of the section.

This PR also fixes a few print styles that should hide some unnecessary elements.

Experimental, feedback is welcome.

-----

Screenshots -

Before expanding:
![Screenshot_2023-06-12_010655](https://github.com/mousetail/openletter/assets/845988/aefa88e8-2e68-4d57-a956-919bc18571f0)

Expanded:
![Screenshot_2023-06-12_010613](https://github.com/mousetail/openletter/assets/845988/9cc58036-bef9-4ce1-aff3-9a1eaa461675)
