### PR TITLE
Mini PR: remove dark.js from views build script

### DIFF
--- a/build-views.sh
+++ b/build-views.sh
@@ -2,7 +2,6 @@ sleep 1 &&
 echo "> mkdir -p build/public/javascripts" &&
 mkdir -p build/public/javascripts &&
 uglifyjs public/javascripts/application.js -c --source-map -o build/public/javascripts/application.js &&
-uglifyjs public/javascripts/dark.js -c --source-map -o build/public/javascripts/dark.js &&
 cp -r views build &&
 cp -r public/stylesheets build/public &&
 cp -r public/images build/public


### PR DESCRIPTION
This is a miniature PR fixing the build script for views in the wake of #45, #46 (dark.js public JS file no longer exists).