### PR TITLE
footer.ejs: Replace broken link to Discord

### DIFF
--- a/views/common/footer.ejs
+++ b/views/common/footer.ejs
@@ -9,7 +9,7 @@
     </p>
     <p>
         Consider joining
-        <a href="https://discord.gg/abJWUdTF" target="_blank">the unofficial Stack Exchange Meta Discord</a>
+        <a href="https://discord.gg/PbEPURd" target="_blank">the unofficial Stack Exchange Meta Discord</a>
         if you want to get involved.
     </p>
     <ul class="list-inline">


### PR DESCRIPTION
As reported in chat, the link has expired.

https://chat.stackoverflow.com/transcript/message/56428592#56428592

